### PR TITLE
Fix encoding in views.py

### DIFF
--- a/views.py
+++ b/views.py
@@ -21,7 +21,7 @@ ROOT = Path(os.path.realpath(__file__)).parent.parent.parent
 from .mailer import send_sfu_email
 
 def read_markdown(md):
-    with open(md) as f:
+    with open(md, encoding='utf-8') as f:
         return f.read()
 
 def index(request):


### PR DESCRIPTION
Make sure to use the UTF-8 encoding for template files.

Without this, ASCII is assumed on some systems. Which leads to crashes.